### PR TITLE
Updated the Toggl hyperlink

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         <li><a href = "http://hipsteripsum.me/?paras=4&type=hipster-centric">Hipster Ipsum</a></li>
         <li><a href ="https://bundler.campfirenow.com/room/566068">Campfire</a></li>
         <li><a href ="https://www.dropbox.com/home/jendiamond">Jen Diamond DropBox/bundler</a></li>
-        <li><a href ="https://www.toggl.com/track#">Toggl</a></li>
+        <li><a href ="https://www.toggl.com/">Toggl</a></li>
       </ul>
   </div><!--/span4-->
   <div class="span4">


### PR DESCRIPTION
The hyperlink was sending visitors to Toggle's 404 Error page.

I just changed https://www.toggl.com/track# to https://www.toggl.com/